### PR TITLE
Ports updated awscli install functions from amigen7

### DIFF
--- a/AWSutils.sh
+++ b/AWSutils.sh
@@ -94,8 +94,10 @@ function EnsurePy3 {
 # Install AWS CLI version 1.x
 function InstallCLIv1 {
    local INSTALLDIR
+   local BINDIR
 
-   INSTALLDIR="opt/aws/cli"
+   INSTALLDIR="/usr/local/aws-cli/v1"
+   BINDIR="/usr/local/bin"
 
    if [[ ${CLIV1SOURCE} == "UNDEF" ]]
    then
@@ -117,10 +119,12 @@ function InstallCLIv1 {
         err_exit "Failed dearchiving awscli-bundle.zip"
 
       err_exit "Installing AWS CLIv1..." NONE
-      chroot "${CHROOTMNT}" /bin/bash -c "(
-            /tmp/awscli-bundle/install -i "/${INSTALLDIR}" -b /usr/local/bin/aws
-         )" || \
-        err_exit "Failed installing AWS CLIv1"
+      chroot "${CHROOTMNT}" /bin/bash -c "/tmp/awscli-bundle/install -i '${INSTALLDIR}' -b '${BINDIR}/aws'" || \
+         err_exit "Failed installing AWS CLIv1"
+
+      err_exit "Creating AWS CLIv1 symlink ${BINDIR}/aws1..." NONE
+      chroot "${CHROOTMNT}" ln -sf "${INSTALLDIR}/bin/aws" "${BINDIR}/aws1" || \
+        err_exit "Failed creating ${BINDIR}/aws1"
 
       err_exit "Cleaning up install files..." NONE
       rm -rf "${CHROOTMNT}/tmp/awscli-bundle.zip" \
@@ -139,8 +143,10 @@ function InstallCLIv1 {
 # Install AWS CLI version 2.x
 function InstallCLIv2 {
    local INSTALLDIR
+   local BINDIR
 
-   INSTALLDIR="opt/aws/cli"
+   INSTALLDIR="/usr/local/aws-cli"  # installer appends v2/current
+   BINDIR="/usr/local/bin"
 
    if [[ ${CLIV2SOURCE} == "UNDEF" ]]
    then
@@ -159,10 +165,12 @@ function InstallCLIv2 {
         err_exit "Failed dearchiving awscli-exe.zip"
 
       err_exit "Installing AWS CLIv2..." NONE
-      chroot "${CHROOTMNT}" /bin/bash -c "(
-            /tmp/aws/install -i "/${INSTALLDIR}" -b /usr/bin
-         )" || \
-        err_exit "Failed installing AWS CLIv1"
+      chroot "${CHROOTMNT}" /bin/bash -c "/tmp/aws/install -i '${INSTALLDIR}' -b '${BINDIR}'" || \
+         err_exit "Failed installing AWS CLIv2"
+
+      err_exit "Creating AWS CLIv2 symlink ${BINDIR}/aws2..." NONE
+      chroot "${CHROOTMNT}" ln -sf "${INSTALLDIR}/v2/current/bin/aws" "${BINDIR}/aws2" || \
+        err_exit "Failed creating ${BINDIR}/aws2"
 
       err_exit "Cleaning up install files..." NONE
       rm -rf "${CHROOTMNT}/tmp/awscli-exe.zip" \


### PR DESCRIPTION
- Install location for the aws cli versions is modified to /usr/local/aws-cli
  as this tracks more closely with the AWS install guides
- Symlinks are created for /usr/local/bin/aws1 and /usr/local/bin/aws2
  to make it easier to use either when both versions are installed alongside
  each other
- When both versions are installed, /usr/local/bin/aws will point to v2