### PR TITLE
Force auto-relabel

### DIFF
--- a/AzureUtils.sh
+++ b/AzureUtils.sh
@@ -98,7 +98,7 @@ function WaagentSetup {
       install --assumeyes --quiet WALinuxAgent || \
       err_exit "Failed installing WALinuxAgent" 1
     err_exit "Success!" NONE
-    
+
   fi
 
   err_exit "Configuring waagent..." NONE

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -407,6 +407,7 @@ function SELsetup {
       err_exit "Running fixfiles in chroot..." NONE
       chroot "${CHROOTMNT}" /sbin/fixfiles -f relabel || \
         err_exit "Errors running fixfiles"
+   # This block *shouldn't* be necessary
    elif [[ $(
       grep -Eq '^SELINUX=(enabled|permissive)' "${CHROOTMNT}/etc/selinux/config"
    )$? -eq 0 ]]
@@ -414,16 +415,14 @@ function SELsetup {
       err_exit "Cofiguring image for relabel-at-boot operation" NONE
       touch "${CHROOTMNT}/.autorelabel" || \
         err_exit "Failed creating /.autorelabel file"
+   # Nor should this block, but...
    else
-      if [[ -d ${CHROOTMNT}/etc/selinux/config ]]
-      then
-         grep '^SELINUX=' "${CHROOTMNT}/etc/selinux/config"
-      else
-         echo "${CHROOTMNT}/etc/selinux/config does not exist"
-         echo "Looking for SELinux config-file..."
-         find -L "${CHROOTMNT}/etc" -type f -print0 | xargs -0 grep -L '^SELINUX='
-         printf "\nDone\n\n"
-      fi
+      # The selinux-policy RPM's %post script currently is not doing The Right
+      # Thing (TM), necessitating the creation of a /.autorelabel file in this
+      # section. Have filed BugZilla ID #2208282 with Red Hat
+      touch "${CHROOTMNT}/.autorelabel" || \
+        err_exit "Failed creating /.autorelabel file"
+
       err_exit "SELinux not available" NONE
    fi
 

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -417,7 +417,7 @@ function SELsetup {
    else
       if [[ -d ${CHROOTMNT}/etc/selinux/config ]]
       then
-         grep '^SELINUX=' ${CHROOTMNT}/etc/selinux/config
+         grep '^SELINUX=' "${CHROOTMNT}/etc/selinux/config"
       else
          echo "${CHROOTMNT}/etc/selinux/config does not exist"
       fi

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -420,6 +420,9 @@ function SELsetup {
          grep '^SELINUX=' "${CHROOTMNT}/etc/selinux/config"
       else
          echo "${CHROOTMNT}/etc/selinux/config does not exist"
+         echo "Looking for SELinux config-file..."
+         find -L "${CHROOTMNT}/etc" -type f -print0 | xargs -0 grep -L '^SELINUX='
+         printf "\nDone\n\n"
       fi
       err_exit "SELinux not available" NONE
    fi

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -415,6 +415,12 @@ function SELsetup {
       touch "${CHROOTMNT}/.autorelabel" || \
         err_exit "Failed creating /.autorelabel file"
    else
+      if [[ -d ${CHROOTMNT}/etc/selinux/config ]]
+      then
+         grep '^SELINUX=' ${CHROOTMNT}/etc/selinux/config
+      else
+         echo "${CHROOTMNT}/etc/selinux/config does not exist"
+      fi
       err_exit "SELinux not available" NONE
    fi
 

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -407,15 +407,6 @@ function SELsetup {
       err_exit "Running fixfiles in chroot..." NONE
       chroot "${CHROOTMNT}" /sbin/fixfiles -f relabel || \
         err_exit "Errors running fixfiles"
-   # This block *shouldn't* be necessary
-   elif [[ $(
-      grep -Eq '^SELINUX=(enabled|permissive)' "${CHROOTMNT}/etc/selinux/config"
-   )$? -eq 0 ]]
-   then
-      err_exit "Cofiguring image for relabel-at-boot operation" NONE
-      touch "${CHROOTMNT}/.autorelabel" || \
-        err_exit "Failed creating /.autorelabel file"
-   # Nor should this block, but...
    else
       # The selinux-policy RPM's %post script currently is not doing The Right
       # Thing (TM), necessitating the creation of a /.autorelabel file in this


### PR DESCRIPTION
Tries to make the `Postbuild.sh` script a bit more-resilient in the face of missing SELinux activation in the bootstrap image.

Note that, due to an issue with how the chroot-installed `selinux-policy` RPM is functioning, creation of a `${CHROOT}/.autorelabel` file is _required_ if the bootstrap-image doesn't have SELinux active.