### PR TITLE
Ensure manifest-file long-flag is actually in getopts list

### DIFF
--- a/OSpackages.sh
+++ b/OSpackages.sh
@@ -361,7 +361,7 @@ function FetchCustomRepos {
 ######################
 OPTIONBUFR=$( getopt \
    -o a:e:Fg:hM:m:r:Xx: \
-   --long cross-distro,exclude-rpms:,extra-rpms:,help,mountpoint:,repo-activation:,repo-rpms:,rpm-group:,setup-dnf: \
+   --long cross-distro,exclude-rpms:,extra-rpms:,help,mountpoint:,pkg-manifest:,repo-activation:,repo-rpms:,rpm-group:,setup-dnf: \
    -n "${PROGNAME}" -- "$@")
 
 eval set -- "${OPTIONBUFR}"


### PR DESCRIPTION
Turns out that there was significantly less surgery to do for this than expected. All of the plumbing was already there. The only thing missing was the long-flag for `getopts` (the short-flag, usage-message and file-read logic was all actually already present)

Closes #93