### PR TITLE
Add support for EFI-enabled bootstrap images

### DIFF
--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -538,13 +538,13 @@ fi
 # Determine how we're formatting the disk
 if [[ -d /sys/firmware/efi ]]
 then
-  if [[ -z ${ROOTLABEL} ]] && [[ -n ${VGNAME} ]]
+  if [[ -z ${ROOTLABEL:-} ]] && [[ -n ${VGNAME:-} ]]
   then
     CarveLVM_Efi
-  elif [[ -n ${ROOTLABEL} ]] && [[ -z ${VGNAME} ]]
+  elif [[ -n ${ROOTLABEL:-} ]] && [[ -z ${VGNAME:-} ]]
   then
     CarveBare_Efi
-  elif [[ -z ${ROOTLABEL} ]] && [[ -z ${VGNAME} ]]
+  elif [[ -z ${ROOTLABEL:-} ]] && [[ -z ${VGNAME:-} ]]
   then
      err_exit "Failed to specifiy a partitioning-method. Aborting"
   else
@@ -553,13 +553,13 @@ then
 
   SetupBootParts_Efi
 else
-  if [[ -z ${ROOTLABEL} ]] && [[ -n ${VGNAME} ]]
+  if [[ -z ${ROOTLABEL:-} ]] && [[ -n ${VGNAME:-} ]]
   then
      CarveLVM_Standard
-  elif [[ -n ${ROOTLABEL} ]] && [[ -z ${VGNAME} ]]
+  elif [[ -n ${ROOTLABEL:-} ]] && [[ -z ${VGNAME:-} ]]
   then
      CarveBare_Standard
-  elif [[ -z ${ROOTLABEL} ]] && [[ -z ${VGNAME} ]]
+  elif [[ -z ${ROOTLABEL:-} ]] && [[ -z ${VGNAME:-} ]]
   then
      err_exit "Failed to specifiy a partitioning-method. Aborting"
   else

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -227,9 +227,7 @@ function CarveLVM_Efi {
     ))m \
     mkpart primary xfs $(( ( 2 + UEFIDEVSZ ) + BOOTDEVSZ ))m 100% \
     set 1 bios_grub on \
-    set 2 esp on \
-    set 3 bls_boot on \
-    set 4 lvm on || \
+    set 2 esp on || \
       err_exit "Failed laying down new partition-table"
 
   ## Create LVM objects
@@ -332,8 +330,7 @@ function CarveBare_Efi {
     ))m \
     mkpart primary xfs $(( ( 2 + UEFIDEVSZ ) + BOOTDEVSZ ))m 100% \
     set 1 bios_grub on \
-    set 2 esp on \
-    set 3 bls_boot on || \
+    set 2 esp on || \
     err_exit "Failed laying down new partition-table"
 
   # Create FS on partitions

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 set -eu -o pipefail
 #
 # Script to automate basic setup of CHROOT device

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -232,16 +232,6 @@ function CarveLVM_Efi {
 
   ## Create LVM objects
 
-  # Let's only attempt this if we're a secondary EBS
-  if [[ ${CHROOTDEV} == /dev/xvda ]] || [[ ${CHROOTDEV} == /dev/nvme0n1 ]]
-  then
-    err_exit "Skipping explicit pvcreate opertion... " NONE
-  else
-    err_exit "Creating LVM2 PV ${CHROOTDEV}${PARTPRE:-}4..." NONE
-    pvcreate "${CHROOTDEV}${PARTPRE:-}4" || \
-      err_exit "PV creation failed. Aborting!"
-  fi
-
   # Create root VolumeGroup
   err_exit "Creating LVM2 volume-group ${VGNAME}..." NONE
   vgcreate -y "${VGNAME}" "${CHROOTDEV}${PARTPRE:-}4" || \

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -54,7 +54,7 @@ function UsageMsg {
    (
       echo "Usage: ${0} [GNU long option] [option] ..."
       echo "  Options:"
-      printf '\t%-4s%s\n' '-b' 'Size of /boot partition (default: 500MiB)'
+      printf '\t%-4s%s\n' '-b' 'Size of /boot partition (default: 400MiB)'
       printf '\t%-4s%s\n' '-B' 'Boot-block size (default: 16MiB)'
       printf '\t%-4s%s\n' '-d' 'Base dev-node used for build-device'
       printf '\t%-4s%s\n' '-f' 'Filesystem-type used for root filesystems (default: xfs)'

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -5,8 +5,8 @@ set -eu -o pipefail
 #
 #################################################################
 PROGNAME=$(basename "$0")
-BOOTDEVSZ="${BOOTDEVSZ:-500}"
-UEFIDEVSZ="${UEFIDEVSZ:-256}"
+BOOTDEVSZ="${BOOTDEVSZ:-400}"
+UEFIDEVSZ="${UEFIDEVSZ:-100}"
 CHROOTDEV="${CHROOTDEV:-UNDEF}"
 DEBUG="${DEBUG:-UNDEF}"
 FSTYPE="${FSTYPE:-xfs}"

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -538,7 +538,20 @@ fi
 # Determine how we're formatting the disk
 if [[ -d /sys/firmware/efi ]]
 then
-  err_exit "Source image is EFI (NOT SUPPORTED): exiting"
+  if [[ -z ${ROOTLABEL} ]] && [[ -n ${VGNAME} ]]
+  then
+    CarveLVM_Efi
+  elif [[ -n ${ROOTLABEL} ]] && [[ -z ${VGNAME} ]]
+  then
+    CarveBare_Efi
+  elif [[ -z ${ROOTLABEL} ]] && [[ -z ${VGNAME} ]]
+  then
+     err_exit "Failed to specifiy a partitioning-method. Aborting"
+  else
+     err_exit "The '-r'/'--rootlabel' and '-v'/'--vgname' flag-options are mutually-exclusive. Exiting." 0
+  fi
+
+  SetupBootParts_Efi
 else
   if [[ -z ${ROOTLABEL} ]] && [[ -n ${VGNAME} ]]
   then

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+!/bin/bash
 set -eu -o pipefail
 #
 # Script to automate basic setup of CHROOT device
@@ -235,7 +235,8 @@ function CarveLVM_Efi {
     ))m \
     mkpart primary xfs $(( ( 2 + UEFIDEVSZ ) + BOOTDEVSZ ))m 100% \
     set 1 bios_grub on \
-    set 2 esp on || \
+    set 2 esp on \
+    set 4 lvm on || \
       err_exit "Failed laying down new partition-table"
 
   ## Create LVM objects

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -543,13 +543,13 @@ if [[ -d /sys/firmware/efi ]]
 then
   err_exit "Source image is EFI (NOT SUPPORTED): exiting"
 else
-  if [[ -z ${ROOTLABEL+xxx} ]] && [[ -n ${VGNAME+xxx} ]]
+  if [[ -z ${ROOTLABEL} ]] && [[ -n ${VGNAME} ]]
   then
      CarveLVM_Standard
-  elif [[ -n ${ROOTLABEL+xxx} ]] && [[ -z ${VGNAME+xxx} ]]
+  elif [[ -n ${ROOTLABEL} ]] && [[ -z ${VGNAME} ]]
   then
      CarveBare_Standard
-  elif [[ -z ${ROOTLABEL+xxx} ]] && [[ -z ${VGNAME+xxx} ]]
+  elif [[ -z ${ROOTLABEL} ]] && [[ -z ${VGNAME} ]]
   then
      err_exit "Failed to specifiy a partitioning-method. Aborting"
   else

--- a/DiskSetup.sh
+++ b/DiskSetup.sh
@@ -78,8 +78,8 @@ function UsageMsg {
    exit "${SCRIPTEXIT}"
 }
 
-# Partition as LVM
-function CarveLVM {
+# Partition as LVM (no EFI)
+function CarveLVM_Standard {
    local ITER
    local MOUNTPT
    local PARTITIONARRAY
@@ -181,8 +181,8 @@ function CarveLVM {
 
 }
 
-# Partition with no LVM
-function CarveBare {
+# Partition with no LVM (no EFI)
+function CarveBare_Standard {
    # Clear the MBR and partition table
    err_exit "Clearing existing partition-tables..." NONE
    dd if=/dev/zero of="${CHROOTDEV}" bs=512 count=1000 > /dev/null 2>&1 || \
@@ -343,10 +343,10 @@ fi
 # Determine how we're formatting the disk
 if [[ -z ${ROOTLABEL+xxx} ]] && [[ -n ${VGNAME+xxx} ]]
 then
-   CarveLVM
+   CarveLVM_Standard
 elif [[ -n ${ROOTLABEL+xxx} ]] && [[ -z ${VGNAME+xxx} ]]
 then
-   CarveBare
+   CarveBare_Standard
 elif [[ -z ${ROOTLABEL+xxx} ]] && [[ -z ${VGNAME+xxx} ]]
 then
    err_exit "Failed to specifiy a partitioning-method. Aborting"

--- a/MkChrootTree.sh
+++ b/MkChrootTree.sh
@@ -392,8 +392,11 @@ else
    DoLvmMounts
 fi
 
-# Mount BIOS and UEFI boot-devices
-MountBootFSes
+# Mount BIOS and UEFI boot-devices as needed
+if [[ -d /sys/firmware/efi ]]
+then
+  MountBootFSes
+fi
 
 # Make block/character-special files
 PrepSpecialDevs

--- a/MkChrootTree.sh
+++ b/MkChrootTree.sh
@@ -155,6 +155,28 @@ function DoLvmMounts {
 
 }
 
+# mount /boot and /boot/efi partitions
+function MountBootFSes {
+
+  # Create /boot mountpoint as needed
+  if [[ ! -d "${CHROOTMNT}/boot" ]]
+  then
+    mkdir "${CHROOTMNT}/boot"
+  fi
+
+  # Mount BIOS-boot partition
+  mount -t "${FSTYPE}" "${CHROOTDEV}${PARTPRE}3" "${CHROOTMNT}/boot"
+
+  # Create /boot/efi mountpoint as needed
+  if [[ ! -d "${CHROOTMNT}/boot/efi" ]]
+  then
+    mkdir "${CHROOTMNT}/boot/efi"
+  fi
+
+  # Mount UEFI-boot partition
+  mount -t vfat "${CHROOTDEV}${PARTPRE}2" "${CHROOTMNT}/boot/efi"
+}
+
 # Create block/character-special files
 function PrepSpecialDevs {
 
@@ -369,6 +391,9 @@ then
 else
    DoLvmMounts
 fi
+
+# Mount BIOS and UEFI boot-devices
+MountBootFSes
 
 # Make block/character-special files
 PrepSpecialDevs

--- a/MkChrootTree.sh
+++ b/MkChrootTree.sh
@@ -347,8 +347,14 @@ fi
 ValidateTgtMnt
 
 ## Mount partition(s) from second slice
-# Locate LVM2 volume-group name
-read -r VGNAME <<< "$( pvs --noheading -o vg_name "${CHROOTDEV}${PARTPRE}2" )"
+if [[ -d /sys/firmware/efi ]]
+then
+  # Locate LVM2 volume-group name (EFI)
+  read -r VGNAME <<< "$( pvs --noheading -o vg_name "${CHROOTDEV}${PARTPRE}4" )"
+else
+  # Locate LVM2 volume-group name (no EFI)
+  read -r VGNAME <<< "$( pvs --noheading -o vg_name "${CHROOTDEV}${PARTPRE}2" )"
+fi
 
 # Do partition-mount if 'no-lvm' explicitly requested
 if [[ ${NOLVM:-} == "true" ]]

--- a/OSpackages.sh
+++ b/OSpackages.sh
@@ -8,8 +8,10 @@ PROGNAME=$(basename "$0")
 CHROOTMNT="${CHROOT:-/mnt/ec2-root}"
 DEBUG="${DEBUG:-UNDEF}"
 GRUBPKGS_X86=(
+      efibootmgr
       grub2-efi-x64
       grub2-efi-x64-modules
+      grub2-pc
       grub2-pc-modules
       grub2-tools
       grub2-tools-efi

--- a/OSpackages.sh
+++ b/OSpackages.sh
@@ -7,6 +7,15 @@ set -eu -o pipefail
 PROGNAME=$(basename "$0")
 CHROOTMNT="${CHROOT:-/mnt/ec2-root}"
 DEBUG="${DEBUG:-UNDEF}"
+GRUBPKGS_X86=(
+      grub2-efi-x64
+      grub2-efi-x64-modules
+      grub2-pc-modules
+      grub2-tools
+      grub2-tools-efi
+      grub2-tools-minimal
+      shim-x64
+)
 MINXTRAPKGS=(
       chrony
       cloud-init
@@ -312,7 +321,16 @@ function MainInstall {
    fi
 
    # Add extra packages to include-list (array)
-   INCLUDEPKGS=( "${INCLUDEPKGS[@]}" "${MINXTRAPKGS[@]}" "${EXTRARPMS[@]}" )
+   INCLUDEPKGS=(
+     "${INCLUDEPKGS[@]}"
+     "${MINXTRAPKGS[@]}"
+     "${EXTRARPMS[@]}"
+   )
+
+   if [[ -d /sys/firmware/efi ]]
+   then
+     INCLUDEPKGS+=( "${GRUBPKGS_X86[@]}" )
+   fi
 
    # Remove excluded packages from include-list
    for EXCLUDE in ${EXCLUDEPKGS[*]} ${EXTRAEXCLUDE[*]}

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -474,6 +474,13 @@ function GrubSetup {
       > ${GRUB_CFG}" || \
      err_exit "Failed to install GRUB config-file"
 
+   # Fix GRUB-config link as necessary
+   if [[ -L /etc/grub2.cfg ]] && [[ ! -e $( readlink -f /etc/grub2.cfg ) ]]
+   then
+     rm /etc/grub2.cfg
+     ln -s "${GRUB_CFG}" /etc/grub2.cfg
+   fi
+
    # Make intramfs in chroot-dev
    if [[ ${FIPSDISABLE} != "true" ]]
    then

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -179,7 +179,7 @@ function CreateFstab {
        sed 's/ /:/g'
      )"
      UEFI_LABEL="$(
-       fatlabel "${UEFI_PART//:*/}"
+       fatlabel "${UEFI_PART//:*/}" | tail -1
      )"
      printf 'LABEL=%s\t/boot/efi\tvfat\tdefaults,rw\t0 0\n' "${UEFI_LABEL}" >> \
        "${CHROOTMNT}/etc/fstab" || \

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -343,6 +343,7 @@ function GrubSetup {
    local CHROOTDEV
    local CHROOTKRN
    local CHROOT_OS_NAME
+   local EFI_DEV
    local GRUBCMDLINE
    local GRUB_CFG
    local ROOTTOK
@@ -452,11 +453,20 @@ function GrubSetup {
    # Install GRUB2 bootloader when EFI not active
    if [[ -d /sys/firmware/efi ]]
    then
+     # Get EFI partition
+     EFI_DEV="$( grep "${CHROOTMNT}/boot/efi" /proc/mounts | sed 's/\s\s*.*//' )"
+
+     # Calculate EFI partition's base-device
+     if [[ ${EFI_DEV} == "/dev/nvme"* ]]
+     then
+       EFI_DEV="${EFI_DEV//p*/}"
+     fi
+
      # Install EFI boot-manager content
      chroot "${CHROOTMNT}" bash -c '
        /sbin/efibootmgr \
          -c \
-         -d /dev/nvme1n1 \
+         -d '"${EFI_DEV}"' \
          -p 1 \
          -l \\EFI\\redhat\\shimx64.efi \
          -L '"${CHROOT_OS_NAME}"'

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -434,8 +434,11 @@ function GrubSetup {
    ) > "${CHROOTMNT}/etc/default/grub" || \
      err_exit "Failed writing default/grub file"
 
-   # Install GRUB2 bootloader
-   chroot "${CHROOTMNT}" /bin/bash -c "/sbin/grub2-install ${CHROOTDEV}"
+   # Install GRUB2 bootloader when EFI not active
+   if [[ ! -d /sys/firmware/efi ]]
+   then
+     chroot "${CHROOTMNT}" /bin/bash -c "/sbin/grub2-install ${CHROOTDEV}"
+   fi
 
    # Install GRUB config-file
    err_exit "Installing GRUB config-file..." NONE

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -409,6 +409,7 @@ function GrubSetup {
    fi
 
    # Get name of OS installed into chroot-env
+   # shellcheck disable=SC2016
    CHROOT_OS_NAME="$(
      chroot "${CHROOTMNT}" \
        awk -F '=' '/^REDHAT_BUGZILLA_PRODUCT=/{ print $2 }' \
@@ -463,6 +464,7 @@ function GrubSetup {
      fi
 
      # Install EFI boot-manager content
+     # shellcheck disable=SC1004
      chroot "${CHROOTMNT}" bash -c '
        /sbin/efibootmgr \
          -c \

--- a/PostBuild.sh
+++ b/PostBuild.sh
@@ -344,6 +344,7 @@ function GrubSetup {
    local CHROOTKRN
    local CHROOT_OS_NAME
    local GRUBCMDLINE
+   local GRUB_CFG
    local ROOTTOK
    local VGCHECK
 
@@ -460,15 +461,17 @@ function GrubSetup {
          -l \\EFI\\redhat\\shimx64.efi \
          -L '"${CHROOT_OS_NAME}"'
      '
+     GRUB_CFG="/boot/efi/EFI/redhat/grub.cfg"
    else
      # Install legacy GRUB2 boot-content
      chroot "${CHROOTMNT}" /bin/bash -c "/sbin/grub2-install ${CHROOTDEV}"
+     GRUB_CFG="/boot/grub2/grub.cfg"
    fi
 
    # Install GRUB config-file
    err_exit "Installing GRUB config-file..." NONE
    chroot "${CHROOTMNT}" /bin/bash -c "/sbin/grub2-mkconfig \
-      > /boot/grub2/grub.cfg" || \
+      > ${GRUB_CFG}" || \
      err_exit "Failed to install GRUB config-file"
 
    # Make intramfs in chroot-dev


### PR DESCRIPTION
Add's conditional logic to the following scripts:

* `DiskSetup.sh`
* `MkChrootTree.sh`
* `OSpackages.sh`
* `PostBuild.sh`

To ensure propper functioning whether the bootstrap AMI is or is not EFI-enabled.

Closes #105